### PR TITLE
Add defer call to prevent timeouts

### DIFF
--- a/quotes.py
+++ b/quotes.py
@@ -40,6 +40,7 @@ class Quotes(commands.Cog):
 
     @commands.slash_command(name="quote", description="Get a random quote")
     async def get_quote(self, ctx):
+        await ctx.defer()
         if self.user_is_in_cooldown(ctx.author):
             await ctx.respond(f"You're doing that too much {ctx.author.mention}! Try again in a bit.")
             return
@@ -79,6 +80,7 @@ class Quotes(commands.Cog):
             contents_substr: discord.Option(str, name="text", description="The quote text to search for", required=False, default=""),
             author: discord.Option(str, description="The name of the quote author", required=False, default=None)
     ):
+        await ctx.defer()
         if contents_substr is None and author is None:
             await ctx.respond("You need to specify at least one of `text` or `author` in your search")
             return
@@ -110,12 +112,14 @@ class Quotes(commands.Cog):
             author: discord.Option(str, description="The author's name"),
             date: discord.Option(str, description="The date the quote was said")
     ):
+        await ctx.defer()
         db.push_quote(quote, author, date)
         self.quotes = db.get_quotes()
         await ctx.respond(f"{ctx.author.mention} Quote added!")
 
     @commands.slash_command(name="refresh", description="Refresh the quotes from the database")
     async def refresh_cached_quotes(self, ctx):
+        await ctx.defer()
         self.quotes = db.get_quotes()
         await ctx.respond("Quotes refreshed!")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ CacheControl==0.12.11
 cachetools==5.2.0
 certifi==2022.6.15.1
 charset-normalizer==2.1.1
-firebase-admin==5.3.0
+firebase-admin==5.4.0
 frozenlist==1.3.1
 google-api-core==2.10.0
 google-api-python-client==2.60.0
@@ -25,12 +25,12 @@ idna==3.3
 msgpack==1.0.4
 multidict==6.0.2
 proto-plus==1.22.1
-protobuf==4.21.5
-py-cord==2.1.3
+protobuf==4.21.7
+py-cord==2.2.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pyparsing==3.0.9
-pytz==2022.2.1
+pytz==2022.4
 requests==2.28.1
 rsa==4.9
 six==1.16.0


### PR DESCRIPTION
Some commands were timing out sporadically with an "application did not respond" error. Turns out there's a 3 second limit on sending a response unless you make a `defer` call. This adds those to the slash commands to prevent the timeout.